### PR TITLE
fix: pass squadFolder to GitHubIssuesService for .squad workspaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const decisionsProvider = new DecisionsTreeProvider(dataProvider, squadFolderName);
 
     // Wire up GitHub Issues service
-    const issuesService = new GitHubIssuesService();
+    const issuesService = new GitHubIssuesService({ squadFolder: squadFolderName });
     teamProvider.setIssuesService(issuesService);
 
     // Create dashboard webview

--- a/src/services/GitHubIssuesService.ts
+++ b/src/services/GitHubIssuesService.ts
@@ -50,6 +50,9 @@ export interface GitHubIssuesServiceOptions {
 
     /** GitHub API base URL (default: https://api.github.com) */
     apiBaseUrl?: string;
+
+    /** Squad folder name (default: '.ai-team') */
+    squadFolder?: '.squad' | '.ai-team';
 }
 
 /**
@@ -66,7 +69,7 @@ export class GitHubIssuesService {
     private issueSourceCache: IssueSourceConfig | null = null;
 
     constructor(options: GitHubIssuesServiceOptions = {}) {
-        this.teamMdService = new TeamMdService();
+        this.teamMdService = new TeamMdService(options.squadFolder);
         this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
         this.token = options.token;
         this.apiBaseUrl = (options.apiBaseUrl ?? 'https://api.github.com').replace(/\/+$/, '');


### PR DESCRIPTION
## Problem

Workspaces using the new `.squad/` folder structure (instead of legacy `.ai-team/`) show **0 issues, 0 milestones, and all members idle** on the Squad Dashboard — even when the GitHub repo has issues with `squad:{member}` labels and milestones configured.

The Team tab shows all members but with `0 open · 0 closed · 0 in progress`, and the Burndown tab shows "No milestone data available."

## Root Cause

`GitHubIssuesService` creates its own `TeamMdService()` with the default `.ai-team` folder (line 69), ignoring the runtime-detected squad folder. When the workspace uses `.squad/`, the service looks for `.ai-team/team.md` which doesn't exist, so `getIssueSource()` returns `null` and all issue/milestone fetches silently return empty arrays.

This was missed in commit 5c01e1f which fixed the same `.ai-team` hardcoding in four other places (SquadDataProvider, SquadDashboardWebview, DecisionsTreeProvider, TeamTreeProvider).

## Fix

- Added `squadFolder` option to `GitHubIssuesServiceOptions`
- Pass it through to `new TeamMdService(options.squadFolder)` — falls back to `.ai-team` when unset (backward compatible)
- Extension now passes the detected `squadFolderName` when constructing the service

## Tests Added

- `.squad` folder team.md is found when `squadFolder: '\.squad'` is passed
- Default service does not find `.squad/team.md` (confirms the bug)
- Constructor passes `squadFolder` through to internal `TeamMdService`
- Default `squadFolder` remains `.ai-team` for backward compatibility

All 1026 existing tests continue to pass.